### PR TITLE
Dynamic imports and  shorter syntax for style modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 
 template/build

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -13,10 +13,10 @@ function getStyleLoader(options) {
   const isModules = options && options.modules;
 
   let styleRegex = /\.css$/;
-  let styleModuleRegex = /\.module\.css$/;
+  let styleModuleRegex = /\.(module|m)\.css$/;
   if (isSass) {
     styleRegex = /\.(scss|sass)$/;
-    styleModuleRegex = /\.module\.(scss|sass)$/;
+    styleModuleRegex = /\.(module|m)\.(scss|sass)$/;
   }
 
   const styleLoader = require.resolve('style-loader');

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -90,7 +90,7 @@ const babelLoader = {
   options: {
     babelrc: false,
     presets: [require.resolve('@babel/preset-react')],
-    // plugins: ["babel-plugin-styled-components"],
+    plugins: [require.resolve("@babel/plugin-syntax-dynamic-import")],
     cacheDirectory: true,
     cacheCompression: false
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.1.6",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-stage-0": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,6 +341,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-dynamic-import@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz#6dfb7d8b6c3be14ce952962f658f3b7eb54c33ee"
+  integrity sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz#0d259a68090e15b383ce3710e01d5b23f3770cbd"


### PR DESCRIPTION
1. Dynamic imports is very powerfull features. We can split build to several chunks. But we need to support of this syntax `import(/* webpackChunkName: "user" */ './@routes/user')`

2. Just little improvement for ability using such name of style module file `styles.m.scss` not only this one `styles.module.scss`