### PR TITLE
Remove deprecated setupTestFrameworkScriptFile

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -15,7 +15,7 @@ module.exports = (resolve, rootDir) => {
   // Use this instead of `paths.testsSetup` to avoid putting
   // an absolute filename into configuration after ejecting.
   const setupTestsFile = fs.existsSync(paths.testsSetup)
-    ? '<rootDir>/src/setupTests.ts'
+    ? ['<rootDir>/src/setupTests.ts']
     : undefined;
 
   // TODO: I don't know if it's safe or not to just use / as path separator
@@ -26,7 +26,7 @@ module.exports = (resolve, rootDir) => {
       resolve('config/polyfills.js'),
       resolve('config/jest/localStoragePolyfill.js')
     ],
-    setupTestFrameworkScriptFile: setupTestsFile,
+    setupFilesAfterEnv: setupTestsFile,
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
       '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}',


### PR DESCRIPTION
Hi Julio,

Hopefully a pretty quick change. Jest 24 has deprecated setupTestFrameworkScriptFile in favor of setupFilesAfterEnv, which takes an array. For now, this PR just simply returns the single item array or undefined. A potential future change would be to append anything from the user's package.json jest setupFilesAfterEnv config into the array.

@edpark11 and I tested this in our app and it's working well. Please let me know if there's any additional testing I can do to make your life easier.

Thanks!